### PR TITLE
Fix blog visibility toggle in navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { sections } from '../config.js'
 
 function Navbar() {
   const [open, setOpen] = useState(false)
@@ -37,9 +38,11 @@ function Navbar() {
             <li>
               <a href="#projects" onClick={closeMenu}>Projects</a>
             </li>
-            <li>
-              <a href="#blog" onClick={closeMenu}>Blog</a>
-            </li>
+            {sections.blog && (
+              <li>
+                <a href="#blog" onClick={closeMenu}>Blog</a>
+              </li>
+            )}
             <li>
               <a href="#contact" onClick={closeMenu}>Contact</a>
             </li>


### PR DESCRIPTION
## Summary
- respect the blog toggle in config when rendering the navbar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877a54a04788328b4c4af5ae9b47006