### PR TITLE
Add hero particles and RX7 background

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,6 +1,9 @@
+import Particles from './Particles.jsx'
+
 function Hero() {
   return (
     <section id="home" className="hero">
+      <Particles />
       <div className="container">
         <div className="hero-content">
           <h1>Paweł Wielga</h1>

--- a/src/components/Particles.jsx
+++ b/src/components/Particles.jsx
@@ -1,0 +1,36 @@
+function Particles({ count = 50 }) {
+  const particles = Array.from({ length: count }).map((_, i) => {
+    const style = {
+      position: 'absolute',
+      width: '2px',
+      height: '2px',
+      background: 'var(--accent-cyan)',
+      borderRadius: '50%',
+      opacity: Math.random() * 0.5,
+      left: `${Math.random() * 100}%`,
+      top: `${Math.random() * 100}%`,
+      animation: `float ${5 + Math.random() * 10}s linear infinite`,
+    }
+    return <div key={i} style={style} />
+  })
+
+  return (
+    <div
+      className="particles"
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        zIndex: 1,
+        pointerEvents: 'none',
+      }}
+    >
+      {particles}
+    </div>
+  )
+}
+
+export default Particles

--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,7 @@ html { scroll-behavior: smooth; }
             display: flex;
             align-items: center;
             position: relative;
+            overflow: hidden;
             background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
         }
 
@@ -132,6 +133,20 @@ html { scroll-behavior: smooth; }
             bottom: 0;
             background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="%23ffffff" stroke-width="0.1" opacity="0.1"/></pattern></defs><rect width="100" height="100" fill="url(%23grid)"/></svg>');
             opacity: 0.1;
+            z-index: 1;
+        }
+
+        .hero::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: url('/img/rx7.png') center/cover no-repeat;
+            opacity: 0.1;
+            filter: grayscale(100%);
+            z-index: 0;
         }
 
         .hero-content {
@@ -483,6 +498,23 @@ html { scroll-behavior: smooth; }
             to {
                 opacity: 1;
                 transform: translateY(0);
+            }
+        }
+
+        @keyframes float {
+            0% {
+                transform: translateY(100vh) rotate(0deg);
+                opacity: 0;
+            }
+            10% {
+                opacity: 0.5;
+            }
+            90% {
+                opacity: 0.5;
+            }
+            100% {
+                transform: translateY(-100vh) rotate(360deg);
+                opacity: 0;
             }
         }
 


### PR DESCRIPTION
## Summary
- restore hero particle effect with new `Particles` component
- add RX7 accent image in hero background
- include float animation keyframes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877a73b8a448328b4c6db1073a2734b