### PR TITLE
Move photo to hero and split skills sections

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -4,11 +4,6 @@ function About() {
       <div className="container">
         <h2 className="section-title scroll-animate">About Me</h2>
         <div className="about-content scroll-animate">
-          <div className="about-image">
-            <div className="profile-img">
-              <i className="fas fa-user-tie" />
-            </div>
-          </div>
           <div className="about-text">
             <h3>Experienced .NET Software Engineer</h3>
             <p>
@@ -30,19 +25,27 @@ function About() {
               innovative 3D printing software solutions including Z-SUITE and
               Zortrax inCloud platforms.
             </p>
-            <div className="tech-stack">
-              <span className="tech-tag">C# .NET</span>
-              <span className="tech-tag">WPF</span>
-              <span className="tech-tag">Blazor</span>
-              <span className="tech-tag">Entity Framework</span>
-              <span className="tech-tag">ASP.NET Core</span>
-              <span className="tech-tag">Angular</span>
-              <span className="tech-tag">TypeScript</span>
-              <span className="tech-tag">RabbitMQ</span>
-              <span className="tech-tag">SignalR</span>
-              <span className="tech-tag">Docker</span>
-              <span className="tech-tag">MongoDB</span>
-              <span className="tech-tag">MySQL</span>
+            <div className="skills-section">
+              <h4>Commercial</h4>
+              <div className="tech-stack">
+                <span className="tech-tag">C# .NET</span>
+                <span className="tech-tag">WPF</span>
+                <span className="tech-tag">Blazor</span>
+                <span className="tech-tag">Entity Framework</span>
+                <span className="tech-tag">ASP.NET Core</span>
+                <span className="tech-tag">Angular</span>
+                <span className="tech-tag">RabbitMQ</span>
+                <span className="tech-tag">SignalR</span>
+                <span className="tech-tag">Docker</span>
+              </div>
+            </div>
+            <div className="skills-section">
+              <h4>Home-made Projects</h4>
+              <div className="tech-stack">
+                <span className="tech-tag">TypeScript</span>
+                <span className="tech-tag">MongoDB</span>
+                <span className="tech-tag">MySQL</span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -6,22 +6,29 @@ function Hero() {
       <Particles />
       <div className="container">
         <div className="hero-content">
-          <h1>Paweł Wielga</h1>
-          <p className="tagline">Building powerful .NET solutions</p>
-          <p className="subtitle">
-            Software Engineer with over 8 years of experience in .NET technologies.
-            Specialized in desktop, web, and mobile applications for industrial
-            environments, banking, and consumer solutions.
-          </p>
-          <div className="cta-buttons">
-            <a href="#projects" className="btn btn-primary">
-              <i className="fas fa-laptop-code" />
-              View My Work
-            </a>
-            <a href="#contact" className="btn btn-secondary">
-              <i className="fas fa-envelope" />
-              Get In Touch
-            </a>
+          <div className="hero-image">
+            <div className="profile-img">
+              <i className="fas fa-user-tie" />
+            </div>
+          </div>
+          <div className="hero-text">
+            <h1>Paweł Wielga</h1>
+            <p className="tagline">Building powerful .NET solutions</p>
+            <p className="subtitle">
+              Software Engineer with over 8 years of experience in .NET technologies.
+              Specialized in desktop, web, and mobile applications for industrial
+              environments, banking, and consumer solutions.
+            </p>
+            <div className="cta-buttons">
+              <a href="#projects" className="btn btn-primary">
+                <i className="fas fa-laptop-code" />
+                View My Work
+              </a>
+              <a href="#contact" className="btn btn-secondary">
+                <i className="fas fa-envelope" />
+                Get In Touch
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -153,6 +153,14 @@ html { scroll-behavior: smooth; }
             position: relative;
             z-index: 2;
             animation: fadeInUp 1s ease-out;
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 60px;
+            align-items: center;
+        }
+
+        .hero-image {
+            text-align: center;
         }
 
         .hero h1 {
@@ -261,10 +269,6 @@ html { scroll-behavior: smooth; }
             align-items: center;
         }
 
-        .about-image {
-            text-align: center;
-        }
-
         .profile-img {
             width: 300px;
             height: 300px;
@@ -295,6 +299,15 @@ html { scroll-behavior: smooth; }
             flex-wrap: wrap;
             gap: 15px;
             margin-top: 30px;
+        }
+
+        .skills-section {
+            margin-top: 30px;
+        }
+
+        .skills-section h4 {
+            margin-bottom: 10px;
+            color: var(--accent-cyan);
         }
 
         .tech-tag {
@@ -545,6 +558,11 @@ html { scroll-behavior: smooth; }
             .cta-buttons {
                 flex-direction: column;
                 align-items: flex-start;
+            }
+
+            .hero-content {
+                grid-template-columns: 1fr;
+                text-align: center;
             }
 
             .about-content {


### PR DESCRIPTION
## Summary
- show profile image in Hero section
- remove image from About section and split skills into two groups
- style Hero for new layout and add skills-section styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877ae5ceb6c8328a7c03c5e16e40a83