### PR TITLE
Make project card clickable and move details button

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,12 +1,17 @@
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 function Projects() {
+  const navigate = useNavigate()
+
   return (
     <section id="projects" className="section">
       <div className="container">
         <h2 className="section-title scroll-animate">My Projects</h2>
         <div className="projects-grid">
-          <div className="project-card scroll-animate">
+          <div
+            className="project-card scroll-animate"
+            onClick={() => navigate('/project/z-suite')}
+          >
             <div className="project-type">Desktop Application</div>
             <h3>Z-SUITE - 3D Printing Software</h3>
             <p>
@@ -24,16 +29,23 @@ function Projects() {
               <span>JavaScript</span>
             </div>
             <div className="project-links">
-              <a href="#">
+              <a href="#" onClick={e => e.stopPropagation()}>
                 <i className="fas fa-cube" /> 3D Printing
               </a>
-              <Link to="/project/z-suite" className="details-link">
+              <Link
+                to="/project/z-suite"
+                className="details-link"
+                onClick={e => e.stopPropagation()}
+              >
                 <i className="fas fa-desktop" /> Details
               </Link>
             </div>
           </div>
 
-          <div className="project-card scroll-animate">
+          <div
+            className="project-card scroll-animate"
+            onClick={() => navigate('/project/incloud')}
+          >
             <div className="project-type">Web Application</div>
             <h3>Zortrax inCloud - Remote Printer Management</h3>
             <p>
@@ -51,10 +63,14 @@ function Projects() {
               <span>MongoDB</span>
             </div>
             <div className="project-links">
-              <a href="#">
+              <a href="#" onClick={e => e.stopPropagation()}>
                 <i className="fas fa-cloud" /> Cloud
               </a>
-              <Link to="/project/incloud" className="details-link">
+              <Link
+                to="/project/incloud"
+                className="details-link"
+                onClick={e => e.stopPropagation()}
+              >
                 <i className="fas fa-globe" /> Details
               </Link>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -329,8 +329,11 @@ html { scroll-behavior: smooth; }
             background: var(--bg-tertiary);
             border-radius: 15px;
             padding: 30px;
+            padding-bottom: 70px;
             transition: all 0.3s ease;
             border: 1px solid transparent;
+            cursor: pointer;
+            position: relative;
         }
 
         .project-card:hover {
@@ -390,6 +393,9 @@ html { scroll-behavior: smooth; }
             display: inline-flex;
             align-items: center;
             gap: 5px;
+            position: absolute;
+            right: 30px;
+            bottom: 30px;
         }
 
         .project-links a:hover {


### PR DESCRIPTION
## Summary
- make project cards navigate to details page when clicked
- stop propagation on inner links so they behave normally
- add cursor and positioning styles for new clickable card behavior
- position details button in the bottom right corner of the card

## Testing
- No tests run due to user request

------
https://chatgpt.com/codex/tasks/task_e_6877bc2d8ff083288a06fea22dc88f3c