### PR TITLE
Handle scrolling when navigating to projects

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -4,9 +4,18 @@ import Projects from './Projects.jsx'
 import Blog from './Blog.jsx'
 import { sections } from '../config.js'
 import useScrollAnimation from '../hooks/useScrollAnimation.js'
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 
 function Home() {
+  const location = useLocation()
   useScrollAnimation()
+  useEffect(() => {
+    if (location.hash === '#projects') {
+      const el = document.getElementById('projects')
+      el?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [location])
 
   return (
     <>

--- a/src/components/ProjectDetails.jsx
+++ b/src/components/ProjectDetails.jsx
@@ -1,4 +1,5 @@
 import { useParams, Link } from 'react-router-dom'
+import { useEffect } from 'react'
 
 const projects = {
   'z-suite': {
@@ -25,6 +26,9 @@ const projects = {
 
 function ProjectDetails() {
   const { id } = useParams()
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
   const project = projects[id]
 
   if (!project) {
@@ -50,7 +54,11 @@ function ProjectDetails() {
             <span key={t}>{t}</span>
           ))}
         </div>
-        <Link to="/" className="read-more" style={{ display: 'inline-block', marginTop: '20px' }}>
+        <Link
+          to="/#projects"
+          className="read-more"
+          style={{ display: 'inline-block', marginTop: '20px' }}
+        >
           Back to projects
         </Link>
       </div>


### PR DESCRIPTION
## Summary
- scroll to top whenever the project detail view loads
- link back to the projects section
- ensure home page scrolls to the projects section when the hash is `#projects`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877cf603ffc83288ddfb560374ac07f