### PR TITLE
Add i18n with language toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
+        "i18next": "^25.3.2",
+        "i18next-browser-languagedetector": "^8.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-i18next": "^15.6.0",
         "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
@@ -270,6 +273,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2058,6 +2070,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz",
+      "integrity": "sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2475,6 +2536,32 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.0.tgz",
+      "integrity": "sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2786,6 +2873,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "i18next": "^25.3.2",
+    "i18next-browser-languagedetector": "^8.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-i18next": "^15.6.0",
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,13 +1,14 @@
+import { useTranslation } from 'react-i18next'
+
 function Footer() {
+  const { t } = useTranslation()
   return (
     <footer id="contact">
       <div className="container">
         <div className="footer-content">
-          <h3>Let's Build Something Amazing Together</h3>
+          <h3>{t('footer.cta')}</h3>
           <p>
-            Experienced in industrial, banking, and consumer applications. Ready to
-            bring technical excellence and innovative solutions to your next .NET
-            project.
+            {t('footer.summary')}
           </p>
           <div className="social-links">
             <a href="#" title="GitHub">
@@ -29,7 +30,7 @@ function Footer() {
           <div className="cta-buttons">
             <a href="mailto::-----------@gmail.com" className="btn btn-primary">
               <i className="fas fa-paper-plane" />
-              Get In Touch
+              {t('footer.getInTouch')}
             </a>
           </div>
         </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,6 +1,8 @@
 import Particles from './Particles.jsx'
+import { useTranslation } from 'react-i18next'
 
 function Hero() {
+  const { t } = useTranslation()
   return (
     <section id="home" className="hero">
       <Particles />
@@ -13,20 +15,18 @@ function Hero() {
           </div>
           <div className="hero-text">
             <h1>Paweł Wielga</h1>
-            <p className="tagline">Building powerful .NET solutions</p>
+            <p className="tagline">{t('hero.tagline')}</p>
             <p className="subtitle">
-              Software Engineer with over 8 years of experience in .NET technologies.
-              Specialized in desktop, web, and mobile applications for industrial
-              environments, banking, and consumer solutions.
+              {t('hero.subtitle')}
             </p>
             <div className="cta-buttons">
               <a href="#projects" className="btn btn-primary">
                 <i className="fas fa-laptop-code" />
-                View My Work
+                {t('hero.viewWork')}
               </a>
               <a href="#contact" className="btn btn-secondary">
                 <i className="fas fa-envelope" />
-                Get In Touch
+                {t('hero.getInTouch')}
               </a>
             </div>
           </div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { sections } from '../config.js'
 
 function Navbar() {
   const [open, setOpen] = useState(false)
+  const { t, i18n } = useTranslation()
 
   useEffect(() => {
     const onScroll = () => {
@@ -19,6 +21,10 @@ function Navbar() {
 
   const toggleMenu = () => setOpen(!open)
   const closeMenu = () => setOpen(false)
+  const toggleLanguage = () => {
+    const newLang = i18n.language === 'en' ? 'pl' : 'en'
+    i18n.changeLanguage(newLang)
+  }
 
   return (
     <nav id="navbar" className="glass">
@@ -30,23 +36,26 @@ function Navbar() {
             style={open ? { display: 'flex', flexDirection: 'column' } : {}}
           >
             <li>
-              <a href="#home" onClick={closeMenu}>Home</a>
+              <a href="#home" onClick={closeMenu}>{t('nav.home')}</a>
             </li>
             <li>
-              <a href="#about" onClick={closeMenu}>About</a>
+              <a href="#about" onClick={closeMenu}>{t('nav.about')}</a>
             </li>
             <li>
-              <a href="#projects" onClick={closeMenu}>Projects</a>
+              <a href="#projects" onClick={closeMenu}>{t('nav.projects')}</a>
             </li>
             {sections.blog && (
               <li>
-                <a href="#blog" onClick={closeMenu}>Blog</a>
+                <a href="#blog" onClick={closeMenu}>{t('nav.blog')}</a>
               </li>
             )}
             <li>
-              <a href="#contact" onClick={closeMenu}>Contact</a>
+              <a href="#contact" onClick={closeMenu}>{t('nav.contact')}</a>
             </li>
           </ul>
+          <button className="lang-btn" onClick={toggleLanguage}>
+            {i18n.language === 'en' ? '🇬🇧' : '🇵🇱'}
+          </button>
           <div className="mobile-menu" onClick={toggleMenu}>
             <i className="fas fa-bars" />
           </div>

--- a/src/components/ProjectDetails.jsx
+++ b/src/components/ProjectDetails.jsx
@@ -1,5 +1,6 @@
 import { useParams, Link } from 'react-router-dom'
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 
 const projects = {
   'z-suite': {
@@ -26,6 +27,7 @@ const projects = {
 
 function ProjectDetails() {
   const { id } = useParams()
+  const { t } = useTranslation()
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [])
@@ -35,9 +37,9 @@ function ProjectDetails() {
     return (
       <section className="section">
         <div className="container">
-          <h2>Project not found</h2>
+          <h2>{t('projectDetails.notFound')}</h2>
           <Link to="/" className="read-more">
-            Back to home
+            {t('projectDetails.backToHome')}
           </Link>
         </div>
       </section>
@@ -59,7 +61,7 @@ function ProjectDetails() {
           className="read-more"
           style={{ display: 'inline-block', marginTop: '20px' }}
         >
-          Back to projects
+          {t('projectDetails.backToProjects')}
         </Link>
       </div>
     </section>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,21 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+import en from './locales/en.json'
+import pl from './locales/pl.json'
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      pl: { translation: pl },
+    },
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+  })
+
+export default i18n

--- a/src/index.css
+++ b/src/index.css
@@ -105,6 +105,19 @@ html { scroll-behavior: smooth; }
             width: 100%;
         }
 
+        .lang-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 1.5rem;
+            color: var(--text-secondary);
+            margin-left: 20px;
+        }
+
+        .lang-btn:hover {
+            color: var(--accent-cyan);
+        }
+
         .mobile-menu {
             display: none;
             color: var(--text-primary);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,25 @@
+{
+  "nav": {
+    "home": "Home",
+    "about": "About",
+    "projects": "Projects",
+    "blog": "Blog",
+    "contact": "Contact"
+  },
+  "hero": {
+    "tagline": "Building powerful .NET solutions",
+    "subtitle": "Software Engineer with over 8 years of experience in .NET technologies. Specialized in desktop, web, and mobile applications for industrial environments, banking, and consumer solutions.",
+    "viewWork": "View My Work",
+    "getInTouch": "Get In Touch"
+  },
+  "footer": {
+    "cta": "Let's Build Something Amazing Together",
+    "summary": "Experienced in industrial, banking, and consumer applications. Ready to bring technical excellence and innovative solutions to your next .NET project.",
+    "getInTouch": "Get In Touch"
+  },
+  "projectDetails": {
+    "backToHome": "Back to home",
+    "backToProjects": "Back to projects",
+    "notFound": "Project not found"
+  }
+}

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1,0 +1,25 @@
+{
+  "nav": {
+    "home": "Strona główna",
+    "about": "O mnie",
+    "projects": "Projekty",
+    "blog": "Blog",
+    "contact": "Kontakt"
+  },
+  "hero": {
+    "tagline": "Tworzę potężne rozwiązania .NET",
+    "subtitle": "Inżynier oprogramowania z ponad 8-letnim doświadczeniem w technologii .NET. Specjalizuję się w aplikacjach desktopowych, webowych i mobilnych dla przemysłu, bankowości oraz rozwiązań konsumenckich.",
+    "viewWork": "Zobacz moje projekty",
+    "getInTouch": "Skontaktuj się"
+  },
+  "footer": {
+    "cta": "Zbudujmy razem coś niesamowitego",
+    "summary": "Doświadczony w aplikacjach przemysłowych, bankowych i konsumenckich. Gotowy dostarczyć techniczną doskonałość i innowacyjne rozwiązania w Twoim następnym projekcie .NET.",
+    "getInTouch": "Skontaktuj się"
+  },
+  "projectDetails": {
+    "backToHome": "Powrót na stronę główną",
+    "backToProjects": "Powrót do projektów",
+    "notFound": "Projekt nie znaleziony"
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './i18n.js'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- add i18next packages
- add i18n initialization and translations
- translate navbar, hero, footer and project details
- add flag button to switch language

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877d0bd34208328b67423613486dfff