### PR TITLE
Fix module loading path in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <!-- Use a relative path so GitHub Pages serves the module correctly -->
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the main React module via a relative path so GitHub Pages resolves it correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877d37a3e2c8328b0e00aada4895c71