### PR TITLE
Fix router base and scroll to details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import './App.css'
 
 function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/src/components/ProjectDetails.jsx
+++ b/src/components/ProjectDetails.jsx
@@ -30,7 +30,7 @@ function ProjectDetails() {
   const { t } = useTranslation()
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [])
+  }, [id])
   const project = projects[id]
 
   if (!project) {


### PR DESCRIPTION
## Summary
- set BrowserRouter basename to the Vite base URL so the deployed app loads the home page
- ensure ProjectDetails view scrolls to top when navigating between projects

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877da620a688328baf848769807fae2