### PR TITLE
Fix hero image path for GitHub Pages

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -10,7 +10,7 @@ function Hero() {
         <div className="hero-content">
           <div className="hero-image">
             <div className="profile-img">
-              <img src="/img/me.jpg" alt="Paweł Wielga" />
+              <img src={`${import.meta.env.BASE_URL}img/me.jpg`} alt="Paweł Wielga" />
             </div>
           </div>
           <div className="hero-text">


### PR DESCRIPTION
## Summary
- load profile photo using the configured `base` URL

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877e6d5363c8328be40fc526e5b95f2