### PR TITLE
Refactor project details into separate modules

### DIFF
--- a/src/components/ProjectDetails.jsx
+++ b/src/components/ProjectDetails.jsx
@@ -2,27 +2,12 @@ import { useParams, Link } from 'react-router-dom'
 import { useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import zSuite from '../projects-details/z-suite.js'
+import inCloud from '../projects-details/incloud.js'
+
 const projects = {
-  'z-suite': {
-    title: 'Z-SUITE - 3D Printing Software',
-    description:
-      'Desktop application with embedded browser for 3D model loading, manipulation, print setting selection, support generation, slicing and toolpath computation.',
-    tech: ['C# .NET', 'WPF', 'CefSharp', 'AngularJS', 'Three.js', 'JavaScript'],
-  },
-  incloud: {
-    title: 'Zortrax inCloud - Remote Printer Management',
-    description:
-      'Web application for remote 3D printer management with real-time status monitoring, job control and data collection.',
-    tech: [
-      '.NET Core',
-      'Entity Framework',
-      'TypeScript',
-      'Angular',
-      'RabbitMQ',
-      'SignalR',
-      'MongoDB',
-    ],
-  },
+  'z-suite': zSuite,
+  incloud: inCloud,
 }
 
 function ProjectDetails() {

--- a/src/projects-details/incloud.js
+++ b/src/projects-details/incloud.js
@@ -1,0 +1,14 @@
+export default {
+  title: 'Zortrax inCloud - Remote Printer Management',
+  description:
+    'Web application for remote 3D printer management with real-time status monitoring, job control and data collection.',
+  tech: [
+    '.NET Core',
+    'Entity Framework',
+    'TypeScript',
+    'Angular',
+    'RabbitMQ',
+    'SignalR',
+    'MongoDB',
+  ],
+}

--- a/src/projects-details/z-suite.js
+++ b/src/projects-details/z-suite.js
@@ -1,0 +1,6 @@
+export default {
+  title: 'Z-SUITE - 3D Printing Software',
+  description:
+    'Desktop application with embedded browser for 3D model loading, manipulation, print setting selection, support generation, slicing and toolpath computation.',
+  tech: ['C# .NET', 'WPF', 'CefSharp', 'AngularJS', 'Three.js', 'JavaScript'],
+}


### PR DESCRIPTION
## Summary
- extract project detail objects into separate modules under `projects-details`
- update `ProjectDetails` component to use the new modules

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877eda3fd50832888234f31141c8deb