### PR TITLE
Fix avatar overlap in mobile view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -572,6 +572,9 @@ html { scroll-behavior: smooth; }
 
         /* Responsive Design */
         @media (max-width: 768px) {
+            .hero {
+                padding-top: 80px;
+            }
             .nav-links {
                 display: none;
             }


### PR DESCRIPTION
## Summary
- bump hero section down below the navbar in mobile view

## Testing
- `npx eslint . --ext js,jsx`

------
https://chatgpt.com/codex/tasks/task_e_687814c9f7788328855e19be02cf3a36