### PR TITLE
Fix order of items in timeline

### DIFF
--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -12,8 +12,8 @@ function Timeline() {
             <div className="timeline-dot" />
             {current && <div className="current-label">CURRENT</div>}
             <div className="timeline-content">
-              <div className="date">{date}</div>
               <div className="company">{company}</div>
+              <div className="date">{date}</div>
             </div>
           </div>
         ))}

--- a/src/index.css
+++ b/src/index.css
@@ -723,7 +723,7 @@ html { scroll-behavior: smooth; }
             font-size: 0.9rem;
             font-weight: 600;
             color: var(--accent-cyan);
-            margin-bottom: 5px;
+            margin-top: 5px;
             white-space: nowrap;
         }
 


### PR DESCRIPTION
## Summary
- reverse order of company/date in the timeline component so company comes first
- update styling for the date element

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878b937e1c4832894d892cfbdf2ebc5