### PR TITLE
Fix CSS typo causing build error

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -254,7 +254,7 @@ html { scroll-behavior: smooth; }
             color: var(--text-primary);
             border: none;
             cursor: pointer;
-            white-space: no
+            white-space: nowrap;
             z-index: 3;
             box-shadow: 0 0 10px rgba(255, 75, 43, 0.5);
         }


### PR DESCRIPTION
## Summary
- fix missing semicolon in `index.css`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878f2d378c08328a8b29b01707d4e4f