### PR TITLE
Split skills by project type

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,6 +1,8 @@
 // import Timeline from './Timeline.jsx'
+import skills from '../skills.json'
 
 function About() {
+  const { commercial, home } = skills
   return (
     <section id="about" className="section">
       <div className="container">
@@ -29,25 +31,27 @@ function About() {
             </p>
             <div className="skills-section">
               <h4>Commercial</h4>
-              <div className="tech-stack">
-                <span className="tech-tag">C# .NET</span>
-                <span className="tech-tag">WPF</span>
-                <span className="tech-tag">Blazor</span>
-                <span className="tech-tag">Entity Framework</span>
-                <span className="tech-tag">ASP.NET Core</span>
-                <span className="tech-tag">Angular</span>
-                <span className="tech-tag">RabbitMQ</span>
-                <span className="tech-tag">SignalR</span>
-                <span className="tech-tag">Docker</span>
-              </div>
+              {commercial.map(({ class: cls, skills: list }) => (
+                <div className="skill-group" key={cls}>
+                  <div className="tech-stack">
+                    {list.map((skill) => (
+                      <span key={skill} className={`tech-tag ${cls}`}>{skill}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
             </div>
             <div className="skills-section">
               <h4>Home-made Projects</h4>
-              <div className="tech-stack">
-                <span className="tech-tag">TypeScript</span>
-                <span className="tech-tag">MongoDB</span>
-                <span className="tech-tag">MySQL</span>
-              </div>
+              {home.map(({ class: cls, skills: list }) => (
+                <div className="skill-group" key={cls}>
+                  <div className="tech-stack">
+                    {list.map((skill) => (
+                      <span key={skill} className={`tech-tag ${cls}`}>{skill}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,8 @@
     --bg-tertiary: #21262d;
     --accent-blue: #007acc;
     --accent-cyan: #00bfff;
+    --accent-orange: #e67e22;
+    --accent-green: #27ae60;
     --text-primary: #ffffff;
     --text-secondary: #e0e0e0;
     --text-muted: #8b949e;
@@ -350,10 +352,15 @@ html { scroll-behavior: smooth; }
             margin-top: 30px;
         }
 
-        .skills-section h4 {
-            margin-bottom: 10px;
-            color: var(--accent-cyan);
-        }
+.skills-section h4 {
+    margin-bottom: 10px;
+    color: var(--accent-cyan);
+}
+
+.skill-group {
+    margin-top: 15px;
+}
+
 
         .tech-tag {
             background: var(--bg-tertiary);
@@ -362,6 +369,26 @@ html { scroll-behavior: smooth; }
             font-size: 0.9rem;
             color: var(--accent-cyan);
             border: 1px solid var(--accent-blue);
+        }
+
+        .tech-tag.languages {
+            color: var(--accent-cyan);
+            border-color: var(--accent-cyan);
+        }
+
+        .tech-tag.frontend {
+            color: var(--accent-blue);
+            border-color: var(--accent-blue);
+        }
+
+        .tech-tag.infra {
+            color: var(--accent-orange);
+            border-color: var(--accent-orange);
+        }
+
+        .tech-tag.database {
+            color: var(--accent-green);
+            border-color: var(--accent-green);
         }
 
         /* Projects Section */

--- a/src/skills.json
+++ b/src/skills.json
@@ -1,0 +1,26 @@
+{
+  "commercial": [
+    {
+      "class": "languages",
+      "skills": ["C# .NET", "ASP.NET Core", "Entity Framework"]
+    },
+    {
+      "class": "frontend",
+      "skills": ["WPF", "Blazor", "Angular"]
+    },
+    {
+      "class": "infra",
+      "skills": ["RabbitMQ", "SignalR", "Docker"]
+    }
+  ],
+  "home": [
+    {
+      "class": "languages",
+      "skills": ["TypeScript"]
+    },
+    {
+      "class": "database",
+      "skills": ["MongoDB", "MySQL"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- organize skill data in `skills.json` under `commercial` and `home` groups
- render separate Commercial and Home-made sections in About page
- add CSS rules for nested skill groups
- remove skill group labels so only color-coded tags show

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68790905480c832883fdbec52e65ffb0