### PR TITLE
Implement slide-in mobile menu

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -32,10 +32,7 @@ function Navbar() {
       <div className="container">
         <div className="nav-container">
           <div className="logo">PW</div>
-          <ul
-            className="nav-links"
-            style={open ? { display: 'flex', flexDirection: 'column' } : {}}
-          >
+          <ul className={`nav-links ${open ? 'open' : ''}`}>
             <li>
               <Link to="/#home" onClick={closeMenu}>
                 {t('nav.home')}
@@ -70,7 +67,7 @@ function Navbar() {
             </li>
           </ul>
           <div className="mobile-menu" onClick={toggleMenu}>
-            <i className="fas fa-bars" />
+            <i className={`fas ${open ? 'fa-times' : 'fa-bars'}`} />
           </div>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -628,7 +628,25 @@ footer {
     padding-top: 80px;
   }
   .nav-links {
-    display: none;
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100vh;
+    width: 250px;
+    background: var(--glass-bg);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    flex-direction: column;
+    padding-top: 80px;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    display: flex;
+    gap: 20px;
+    z-index: 999;
+  }
+
+  .nav-links.open {
+    transform: translateX(0);
   }
 
   .mobile-menu {


### PR DESCRIPTION
## Summary
- make navbar mobile menu slide in from the right
- show close icon when menu is open

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b4710c9008328b2916b5652e22b4e