### PR TITLE
Add missing skill tag styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,8 @@
   --accent-orange: #e67e22;
   --accent-green: #27ae60;
   --accent-purple: #9b59b6;
+  --accent-red: #e74c3c;
+  --accent-yellow: #f1c40f;
   --text-primary: #ffffff;
   --text-secondary: #e0e0e0;
   --text-muted: #8b949e;
@@ -394,6 +396,7 @@ nav.scrolled {
   border-color: var(--accent-blue);
 }
 
+.tech-tag.infrastructure,
 .tech-tag.infra {
   color: var(--accent-orange);
   border-color: var(--accent-orange);
@@ -407,6 +410,16 @@ nav.scrolled {
 .tech-tag.devops {
   color: var(--accent-purple);
   border-color: var(--accent-purple);
+}
+
+.tech-tag.backend {
+  color: var(--accent-red);
+  border-color: var(--accent-red);
+}
+
+.tech-tag.patterns {
+  color: var(--accent-yellow);
+  border-color: var(--accent-yellow);
 }
 
 /* Projects Section */


### PR DESCRIPTION
## Summary
- add accent color variables for red and yellow
- style new skill tags for backend, infrastructure, and patterns

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b7fc05a948328a5bc156e5be8a3f1