### PR TITLE
Fix mobile hero button layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -694,8 +694,9 @@ footer {
   }
 
   .cta-buttons {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
   }
 
   .hero-content {


### PR DESCRIPTION
## Summary
- keep hero CTA buttons on one row even on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bdecc663483288775bf5040fe9815