### PR TITLE
Change project links to text

### DIFF
--- a/src/components/projects/projectCardRenderer.jsx
+++ b/src/components/projects/projectCardRenderer.jsx
@@ -10,9 +10,7 @@ function RenderCard({ project }) {
       onClick={() => project.hasDetails && navigate(`/project/${project.id}`)}
     >
       <div className="project-type">{project.type}</div>
-      {project.company && (
-        <div className="project-company">{project.company}</div>
-      )}
+      {project.company && <div className="project-company">{project.company}</div>}
       <h3>{project.title}</h3>
       <p>{project.description}</p>
       <div className="project-tech">
@@ -22,9 +20,9 @@ function RenderCard({ project }) {
       </div>
       <div className="project-links">
         {project.links.map((link) => (
-          <a key={link.label} href="#" onClick={(e) => e.stopPropagation()}>
+          <span key={link.label}>
             <i className={link.icon} /> {link.label}
-          </a>
+          </span>
         ))}
         {project.hasDetails && (
           <Link


### PR DESCRIPTION
## Summary
- show project links as plain text

## Testing
- `npm run lint` *(fails: no-unused-vars in Hero.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_687bf5d94ab88328b0f6db07e817ffc4