### PR TITLE
Fix hero height on Safari iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -114,7 +114,6 @@ nav.scrolled {
   width: 100%;
 }
 
-
 .mobile-menu {
   display: none;
   color: var(--text-primary);
@@ -136,6 +135,8 @@ nav.scrolled {
 /* Hero Section */
 .hero {
   height: 100vh;
+  height: 100dvh; /* fix Safari iOS viewport issue */
+  min-height: 100vh;
   display: flex;
   align-items: center;
   position: relative;


### PR DESCRIPTION
## Summary
- prevent hero section from being cut off in mobile Safari by using `100dvh`

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687bfae877208328b64402814c38fee0