### PR TITLE
Add scroll to top button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Navbar from './components/Navbar.jsx';
 import Footer from './components/Footer.jsx';
 import Home from './components/Home.jsx';
 import ProjectDetails from './components/projects/ProjectDetails.jsx';
+import ScrollToTop from './components/ScrollToTop.jsx';
 import './App.css';
 
 function App() {
@@ -14,6 +15,7 @@ function App() {
         <Route path="/project/:id" element={<ProjectDetails />} />
       </Routes>
       <Footer />
+      <ScrollToTop />
     </BrowserRouter>
   );
 }

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -3,14 +3,6 @@ import { useTranslation } from 'react-i18next';
 
 function Hero() {
   const { t } = useTranslation();
-  const underConstruction = t('hero.underConstruction');
-  let parts = underConstruction.split(' - ');
-  let dash = ' -';
-  if (parts.length === 1) {
-    parts = underConstruction.split(' – ');
-    dash = ' –';
-  }
-  const [before, after] = parts;
 
   return (
     <section id="home" className="hero">

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+
+function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const atTop = window.scrollY === 0;
+      const isDesktop = window.innerWidth >= 1024;
+      if (!atTop && isDesktop) {
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    visible && (
+      <button
+        className="scroll-top-btn"
+        onClick={scrollToTop}
+        aria-label="Scroll to top"
+      >
+        <i className="fas fa-arrow-up" />
+      </button>
+    )
+  );
+}
+
+export default ScrollToTop;

--- a/src/index.css
+++ b/src/index.css
@@ -902,3 +902,27 @@ footer {
     font-size: 0.8rem;
   }
 }
+
+.scroll-top-btn {
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: transparent;
+  border: 2px solid var(--text-muted);
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1000;
+  transition: border-color 0.3s, box-shadow 0.3s, color 0.3s;
+}
+
+.scroll-top-btn:hover {
+  border-color: var(--accent-cyan);
+  box-shadow: var(--glow);
+  color: var(--accent-cyan);
+}


### PR DESCRIPTION
## Summary
- add ScrollToTop component displayed on desktop when page is scrolled
- include ScrollToTop in the main App layout
- style scroll-top button
- fix unused vars from `Hero.jsx`
- update scroll-to-top styles to be transparent with gray border and cyan glow on hover

## Testing
- No tests run per instructions

------
https://chatgpt.com/codex/tasks/task_e_687bfc00c4d48328ba3926115b073188