### PR TITLE
Add centered highlight effect

### DIFF
--- a/src/components/projects/projectCardRenderer.jsx
+++ b/src/components/projects/projectCardRenderer.jsx
@@ -1,11 +1,16 @@
 import { Link, useNavigate } from 'react-router-dom';
+import { useRef } from 'react';
+import useCenteredHighlight from '../../hooks/useCenteredHighlight.js';
 
 function RenderCard({ project }) {
   const navigate = useNavigate();
+  const cardRef = useRef(null);
+  useCenteredHighlight(cardRef);
 
   return (
     <div
       key={project.id}
+      ref={cardRef}
       className="project-card glass scroll-animate"
       onClick={() => project.hasDetails && navigate(`/project/${project.id}`)}
     >

--- a/src/hooks/useCenteredHighlight.js
+++ b/src/hooks/useCenteredHighlight.js
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+export default function useCenteredHighlight(ref) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const options = {
+      root: null,
+      rootMargin: '-45% 0px -45% 0px',
+      threshold: 0.5,
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('center-highlight');
+        } else {
+          entry.target.classList.remove('center-highlight');
+        }
+      });
+    }, options);
+
+    observer.observe(el);
+    return () => observer.unobserve(el);
+  }, [ref]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -447,6 +447,12 @@ footer {
   overflow: hidden;
 }
 
+
+.center-highlight {
+  box-shadow: var(--glow);
+  border-color: var(--accent-cyan);
+}
+
 .project-card:hover {
   transform: translateY(-10px);
   border-color: var(--accent-cyan);


### PR DESCRIPTION
## Summary
- add `useCenteredHighlight` hook using IntersectionObserver
- highlight project card when it enters viewport center
- style `.center-highlight` with a glow

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c095adb3c832894cf691de751b8bc