### PR TITLE
Fix Safari hero CTA spacing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -213,6 +213,12 @@ nav.scrolled {
   margin-top: 40px;
 }
 
+@supports (-webkit-touch-callout: none) {
+  .hero .cta-buttons {
+    margin-bottom: 20px;
+  }
+}
+
 .btn {
   padding: 15px 30px;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- add Safari-specific margin under the hero CTA buttons so they don't touch the bottom of the section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c182ad18483288f80f1aa2385248e