### PR TITLE
Limit scroll glow to mobile

### DIFF
--- a/src/hooks/useCenteredHighlight.js
+++ b/src/hooks/useCenteredHighlight.js
@@ -5,6 +5,12 @@ export default function useCenteredHighlight(ref) {
     const el = ref.current;
     if (!el) return;
 
+    const isMobile =
+      typeof navigator !== 'undefined' &&
+      /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+
+    if (!isMobile) return;
+
     const options = {
       root: null,
       // shrink viewport to center 10% to detect when the card's middle enters


### PR DESCRIPTION
## Summary
- limit useCenteredHighlight hook to activate only on mobile devices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cbf2a24dc832882b1dc107ea2febc