### PR TITLE
Add blog post routing and JSON data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Navbar from './components/Navbar.jsx';
 import Footer from './components/Footer.jsx';
 import Home from './components/Home.jsx';
 import ProjectDetails from './components/projects/ProjectDetails.jsx';
+import BlogPostDetails from './components/blog/BlogPostDetails.jsx';
 import ScrollToTop from './components/ScrollToTop.jsx';
 import './App.css';
 
@@ -13,6 +14,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/project/:id" element={<ProjectDetails />} />
+        <Route path="/blog/:id" element={<BlogPostDetails />} />
       </Routes>
       <Footer />
       <ScrollToTop />

--- a/src/components/Blog.jsx
+++ b/src/components/Blog.jsx
@@ -1,110 +1,27 @@
+import { blogPostList } from '../data/blogposts';
+import { Link } from 'react-router-dom';
+
 function Blog() {
   return (
     <section id="blog" className="section">
       <div className="container">
         <h2 className="section-title scroll-animate">Latest Blog Posts</h2>
         <div className="blog-grid">
-          <article className="blog-card scroll-animate">
-            <div className="blog-image">
-              <i className="fas fa-cube" />
-            </div>
-            <div className="blog-content">
-              <div className="blog-date">June 10, 2025</div>
-              <h3>3D Printing Software: Lessons from Z-SUITE Development</h3>
-              <p>
-                Deep dive into building desktop applications for 3D printing, covering 3D
-                transformations, collision detection, and optimal model orientation algorithms.
-              </p>
-              <a href="#" className="read-more">
-                Read More <i className="fas fa-arrow-right" />
-              </a>
-            </div>
-          </article>
-
-          <article className="blog-card scroll-animate">
-            <div className="blog-image">
-              <i className="fas fa-university" />
-            </div>
-            <div className="blog-content">
-              <div className="blog-date">June 5, 2025</div>
-              <h3>Migrating from T-SQL to C# Services in Banking</h3>
-              <p>
-                Practical insights from migrating complex business logic from stored procedures to
-                maintainable C# services in enterprise banking environments.
-              </p>
-              <a href="#" className="read-more">
-                Read More <i className="fas fa-arrow-right" />
-              </a>
-            </div>
-          </article>
-
-          <article className="blog-card scroll-animate">
-            <div className="blog-image">
-              <i className="fas fa-mobile-alt" />
-            </div>
-            <div className="blog-content">
-              <div className="blog-date">May 28, 2025</div>
-              <h3>Building Cross-Platform Apps with .NET MAUI</h3>
-              <p>
-                My experience building "Nie Ma Nudy" - from concept to production, covering .NET
-                MAUI, Blazor integration, and location-based features.
-              </p>
-              <a href="#" className="read-more">
-                Read More <i className="fas fa-arrow-right" />
-              </a>
-            </div>
-          </article>
-
-          <article className="blog-card scroll-animate">
-            <div className="blog-image">
-              <i className="fas fa-cogs" />
-            </div>
-            <div className="blog-content">
-              <div className="blog-date">May 20, 2025</div>
-              <h3>MVVM and DDD Patterns in Industrial Applications</h3>
-              <p>
-                How architectural patterns like MVVM and Domain-Driven Design helped build robust,
-                maintainable solutions in complex industrial environments.
-              </p>
-              <a href="#" className="read-more">
-                Read More <i className="fas fa-arrow-right" />
-              </a>
-            </div>
-          </article>
-
-          <article className="blog-card scroll-animate">
-            <div className="blog-image">
-              <i className="fas fa-cloud" />
-            </div>
-            <div className="blog-content">
-              <div className="blog-date">May 15, 2025</div>
-              <h3>Real-time Communication with SignalR and RabbitMQ</h3>
-              <p>
-                Building responsive applications with asynchronous communication patterns, covering
-                implementation strategies and performance considerations.
-              </p>
-              <a href="#" className="read-more">
-                Read More <i className="fas fa-arrow-right" />
-              </a>
-            </div>
-          </article>
-
-          <article className="blog-card scroll-animate">
-            <div className="blog-image">
-              <i className="fas fa-paint-brush" />
-            </div>
-            <div className="blog-content">
-              <div className="blog-date">May 8, 2025</div>
-              <h3>Custom Graphics with SkiaSharp in Xamarin</h3>
-              <p>
-                Creating interactive touch interfaces and custom visualizations using SkiaSharp,
-                based on experience building the ShowSize measurement app.
-              </p>
-              <a href="#" className="read-more">
-                Read More <i className="fas fa-arrow-right" />
-              </a>
-            </div>
-          </article>
+          {blogPostList.map((post) => (
+            <article key={post.id} className="blog-card scroll-animate">
+              <div className="blog-image">
+                <i className="fas fa-file-alt" />
+              </div>
+              <div className="blog-content">
+                <div className="blog-date">{post.date}</div>
+                <h3>{post.title}</h3>
+                <p>{post.summary}</p>
+                <Link to={`/blog/${post.id}`} className="read-more">
+                  Read More <i className="fas fa-arrow-right" />
+                </Link>
+              </div>
+            </article>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/blog/BlogPostDetails.jsx
+++ b/src/components/blog/BlogPostDetails.jsx
@@ -1,0 +1,62 @@
+import { useParams, Link } from 'react-router-dom';
+import { useLayoutEffect } from 'react';
+import { blogPostMap } from '../../data/blogposts';
+
+function BlogPostDetails() {
+  const { id } = useParams();
+  useLayoutEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [id]);
+
+  const post = blogPostMap[id];
+
+  if (!post) {
+    return (
+      <section className="section">
+        <div className="container">
+          <h2>Post not found</h2>
+          <Link to="/" className="read-more">
+            Back to home
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="section">
+      <div className="container">
+        <h2 className="section-title">{post.title}</h2>
+        <div className="blog-date" style={{ marginBottom: '20px' }}>{post.date}</div>
+        {post.content.map((block, idx) => {
+          if (block.type === 'text') {
+            return <p key={idx}>{block.text}</p>;
+          }
+          if (block.type === 'code') {
+            return (
+              <pre key={idx} style={{ overflowX: 'auto' }}>
+                <code className={`language-${block.language}`}>{block.lines.join('\n')}</code>
+              </pre>
+            );
+          }
+          if (block.type === 'image') {
+            return (
+              <img
+                key={idx}
+                src={`${import.meta.env.BASE_URL}${block.url}`}
+                alt={block.alt || ''}
+                style={{ maxWidth: '100%', margin: '20px 0' }}
+              />
+            );
+          }
+          return null;
+        })}
+        <Link to="/#blog" className="read-more" style={{ display: 'inline-block', marginTop: '20px' }}>
+          <i className="fas fa-arrow-left" /> Back to blog
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export default BlogPostDetails;

--- a/src/config/sections.js
+++ b/src/config/sections.js
@@ -2,6 +2,6 @@ export const sections = {
   hero: true,
   about: true,
   projects: true,
-  blog: false,
+  blog: true,
   footer: true,
 };

--- a/src/data/blogposts/hello-homeassistant.json
+++ b/src/data/blogposts/hello-homeassistant.json
@@ -1,0 +1,18 @@
+{
+  "id": "hello-homeassistant",
+  "title": "How to integrate Home Assistant",
+  "date": "23.03.2025",
+  "tags": ["HomeAssistant", "hello"],
+  "summary": "A brief introduction to integrating Home Assistant with custom components.",
+  "content": [
+    { "type": "text", "text": "lorem ipsum" },
+    {
+      "type": "code",
+      "language": "csharp",
+      "lines": ["console.log(s);", "todo: something"]
+    },
+    { "type": "text", "text": "lorem ipsum" },
+    { "type": "image", "url": "img/example.jpg", "alt": "Example" },
+    { "type": "text", "text": "lorem ipsum" }
+  ]
+}

--- a/src/data/blogposts/index.js
+++ b/src/data/blogposts/index.js
@@ -1,1 +1,9 @@
-//TODO
+import helloHomeassistant from './hello-homeassistant.json';
+import migratingTsql from './migrating-tsql.json';
+
+export const blogPostMap = {
+  [helloHomeassistant.id]: helloHomeassistant,
+  [migratingTsql.id]: migratingTsql,
+};
+
+export const blogPostList = Object.values(blogPostMap);

--- a/src/data/blogposts/migrating-tsql.json
+++ b/src/data/blogposts/migrating-tsql.json
@@ -1,0 +1,16 @@
+{
+  "id": "migrating-tsql",
+  "title": "Migrating from T-SQL to C# Services",
+  "date": "05.06.2025",
+  "tags": ["Banking", "C#"],
+  "summary": "Practical insights on moving complex logic from stored procedures to services.",
+  "content": [
+    { "type": "text", "text": "lorem ipsum" },
+    {
+      "type": "code",
+      "language": "csharp",
+      "lines": ["// migration snippet", "Console.WriteLine(\"Hello\");"]
+    },
+    { "type": "text", "text": "more lorem" }
+  ]
+}


### PR DESCRIPTION
## Summary
- enable blog section
- store blog posts as JSON and export them
- show post cards from data
- add BlogPostDetails component for single article view
- route `/blog/:id` for articles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cc98661e88328a59ea96ee3dcbdf3