### PR TITLE
Add gh-pages redirects for blog and 404 support

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,15 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <script>
+      (function () {
+        const redirect = sessionStorage.getItem('redirect');
+        if (redirect) {
+          sessionStorage.removeItem('redirect');
+          window.history.replaceState(null, null, redirect);
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting…</title>
+    <script>
+      sessionStorage.setItem('redirect', location.pathname + location.search + location.hash);
+      location.replace('/');
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { sections } from '../config/sections';
 
 function Navbar() {
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
## Summary
- handle gh-pages redirects in index.html
- add 404 placeholder page to support deep links without per-post HTML

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_688faffc3f8483289e9609f33e0d17c8