### PR TITLE
fix(ci): ignore peer deps in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci || npm i
+        run: npm ci --legacy-peer-deps || npm i --legacy-peer-deps
 
       - name: Generate sitemap.xml
         run: node ./scripts/generate-sitemap.mjs

--- a/.github/workflows/sitemap.yml
+++ b/.github/workflows/sitemap.yml
@@ -30,7 +30,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies (CI-friendly)
-        run: npm ci || npm i
+        run: npm ci --legacy-peer-deps || npm i --legacy-peer-deps
 
       - name: Generate sitemap.xml
         run: node ./scripts/generate-sitemap.mjs


### PR DESCRIPTION
## Summary
- allow npm to bypass peer dependency checks in CI workflows to support React 19

## Testing
- `npm ci --legacy-peer-deps`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fdd9679e88328966533873c69335f