### PR TITLE
Fix sitemap generation

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://pawelwielga.dihor.pl/</loc>
+    <lastmod>2025-08-03T22:16:50.403Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://pawelwielga.dihor.pl/blog</loc>
+    <lastmod>2025-08-03T22:16:50.403Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://pawelwielga.dihor.pl/blog/nextcloud-przez-cloudflare-tunnel</loc>
+    <lastmod>2025-07-05T00:00:00.000Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://pawelwielga.dihor.pl/blog/reverse-proxy-nginx-pihole</loc>
+    <lastmod>2025-06-14T00:00:00.000Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- parse blog post sources directly to build sitemap without evaluating undefined imports
- include generated sitemap.xml in public assets

## Testing
- `node ./scripts/generate-sitemap.mjs`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fdf187d4c83288f6d6d38d96a99cd